### PR TITLE
Prevent the build stage from getting stuck

### DIFF
--- a/lib/winter/service/build.rb
+++ b/lib/winter/service/build.rb
@@ -69,7 +69,7 @@ module Winter
         end
       end
       #wait for stragglers
-      sleep while (active_threads > 0) 
+      sleep 1 while (active_threads > 0) 
     end
   end
 end


### PR DESCRIPTION
Long story short there is a race condition in the threaded build stuff that will occasionally hang winter.

Add a sleep timeout to the final wait sleep loop so that if we get a signal just after we check the loop condition, but before we sleep, we don't get stuck. 
