### PR TITLE
Patch for some bugs related to child process management.

### DIFF
--- a/lib/winter/dependency.rb
+++ b/lib/winter/dependency.rb
@@ -40,8 +40,8 @@ module Winter
 
     def getMaven
       dest_file = File.join(@destination,outputFilename)
-
-      c =  "mvn org.apache.maven.plugins:maven-dependency-plugin:2.5:get " 
+      
+      c =  "exec mvn org.apache.maven.plugins:maven-dependency-plugin:2.5:get " 
       c << " -DremoteRepositories=#{@repositories.join(',').shellescape}" 
       c << " -Dtransitive=#{@transative}" 
       c << " -Dartifact=#{@group.shellescape}:#{@artifact.shellescape}:#{@version.shellescape}:#{@package.shellescape}" 

--- a/lib/winter/service/start.rb
+++ b/lib/winter/service/start.rb
@@ -83,7 +83,6 @@ module Winter
         $LOG.error "PID file already exists. Is the process running?"
         exit
       end
-      pid_file = File.open(File.join(@service_dir, "pid"), "w")
 
       # Normally, we'd just use Process.daemon for ruby 1.9, but for some
       # reason the OSGi container we're using crashes when the CWD is changed
@@ -98,6 +97,7 @@ module Winter
         exec(java_cmd)
       end
 
+      pid_file = File.open(File.join(@service_dir, "pid"), "w")
       pid = java_pid
       pid_file.write(pid)
       pid_file.close      

--- a/lib/winter/service/start.rb
+++ b/lib/winter/service/start.rb
@@ -70,10 +70,15 @@ module Winter
       @directives.merge! dsl[:directives]
 
       java_cmd = generate_java_invocation
-      java_cmd << " > #{@config['console']} 2>&1"
+      
+      if @config['daemonize']
+        java_cmd <<  " 2>&1 " #"don't eat the log thats evil"
+      else 
+        java_cmd << " > #{@config['console']} 2>&1"
+      end
       $LOG.debug java_cmd
 
-      # execute
+      # 
       if( File.exists?(File.join(@service_dir, "pid")) )
         $LOG.error "PID file already exists. Is the process running?"
         exit
@@ -84,72 +89,20 @@ module Winter
       # reason the OSGi container we're using crashes when the CWD is changed
       # to '/'. So, we'll just leave the CWD alone.
       #Process.daemon(Dir.getwd,nil)
-
+      
+      exec(java_cmd) if @config['daemonize'] #Let the child eat winter so things are awesome for daemontools
+      #We never hit the past this point if  we went to daemonize mode.
+      
+      #If we're not trying to run as a daemon just fork and let the subprocess be eaten
       java_pid = fork do
         exec(java_cmd)
       end
 
       pid = java_pid
-      pid = Process.pid if @config['daemonize'] 
       pid_file.write(pid)
       pid_file.close      
 
       $LOG.info "Started #{@config['service']} (#{pid})"
-
-      if( @config['daemonize'] )
-        stay_resident(java_pid,winterfile)
-      end
-    end
-
-    def stay_resident( child_pid, winterfile )
-      interrupted = false
-
-      #TERM, CONT STOP HUP ALRM INT and KILL
-      Signal.trap("EXIT") do
-        $LOG.debug "EXIT Terminating... #{$$}"
-        interrupted = true
-        begin
-          stop winterfile
-         # not working...
-         # Process.getpgid child_pid 
-         # Process.kill child_pid #skipped if process is alredy dead
-        rescue
-          $LOG.debug "Child pid (#{child_pid}) is already gone."
-        end
-      end
-      Signal.trap("HUP") do
-        $LOG.debug "HUP Terminating... #{$$}"
-        interrupted = true
-      end
-      Signal.trap("TERM") do
-        $LOG.debug "TERM Terminating... #{$$}"
-        interrupted = true
-      end
-      Signal.trap("KILL") do
-        $LOG.debug "KILL Terminating... #{$$}"
-        interrupted = true
-      end
-      Signal.trap("CONT") do
-        $LOG.debug "CONT Terminating... #{$$}"
-        interrupted = true
-      end
-      Signal.trap("ALRM") do
-        $LOG.debug "ALRM Terminating... #{$$}"
-        interrupted = true
-      end
-      Signal.trap("INT") do
-        $LOG.debug "INT Terminating... #{$$}"
-        interrupted = true
-      end
-      Signal.trap("CHLD") do
-        $LOG.debug "CHLD Terminating... #{$$}"
-        interrupted = true
-      end
-      #Process.detach(pid)
-
-      while 1
-        exit 0 if interrupted
-      end
     end
 
     def find_java
@@ -172,7 +125,7 @@ module Winter
       felix_jar = File.join(@felix.destination,"#{@felix.artifact}-#{@felix.version}.#{@felix.package}")
 
       # start building the command
-      cmd = [ "#{java_bin.shellescape} -server" ]
+      cmd = [ "exec #{java_bin.shellescape} -server" ] 
       cmd << (@config["64bit"]==true ? " -d64 -XX:+UseCompressedOops":'')
       cmd << " -XX:MaxPermSize=256m -XX:NewRatio=3"
       cmd << " -Xmx#{@config['jvm.mx']}" 

--- a/lib/winter/service/status.rb
+++ b/lib/winter/service/status.rb
@@ -31,14 +31,17 @@ module Winter
         service = f_pid.sub( %r{#{WINTERFELL_DIR}/#{RUN_DIR}/([^/]+)/pid}, '\1')
         pid_file = File.open(f_pid, "r")
         pid = pid_file.read().to_i
-      
-        begin
-          Process.getpgid( pid )
-          running = "Running"
-        rescue Errno::ESRCH
-          running = "Dangling pid file : #{f_pid}"
+        
+        if pid <= 0 
+          running = "A pid of zero was found... something bad is going on" 
+        else 
+          begin
+            Process.getpgid( pid )
+            running = "Running"
+          rescue Errno::ESRCH
+            running = "Dangling pid file : #{f_pid}"
+          end
         end
-
         services["#{service} (#{pid})"] = "#{running}"
       end
 

--- a/lib/winter/service/stop.rb
+++ b/lib/winter/service/stop.rb
@@ -31,21 +31,39 @@ module Winter
 
       @service_dir = File.join(File.split(winterfile)[0],RUN_DIR,service)
       f_pid = File.join(@service_dir, "pid")
-
       if File.exists?(f_pid)
-        pid = nil;
+        pid = nil
+        pid_string = nil
         File.open(f_pid, "r") do |f|
-          pid = f.read().to_i
+          pid_string = f.read()
+          pid = pid_string.to_i
         end
 
-        begin
-          Process.kill("TERM", pid)
-        rescue => e
-          $LOG.debug( e )
-          $LOG.info( "Process #{pid} does not exist. Removing pid file." )
+        #Send a TERM to the container if we have a non bogus pid
+        if pid > 0 
+          begin
+            $LOG.info("Attempting to terminate #{pid}")
+            Process.kill("TERM", pid)
+          rescue => e
+            $LOG.debug( e )
+            $LOG.info("Unable to control process with pid #{pid}.")
+            $LOG.info("Either your user has insufficent rights, or the process doesn't exist")
+          end
+          
+          #Wait for things to stop. 
+          begin 
+            $LOG.info("Waiting for the process with pid #{pid} to stop")
+            sleep 1 while Process.kill(0,pid)
+          rescue => e
+            $LOG.info("The container seems to have exited.")
+          end
+        else
+          $LOG.info("An invalid pid value was found in the pid file. (\"#{pid_string}\" was parsed as #{pid})")
         end
-
+        
+        #If things worked (Or we couldn't find a pid)... then we're good to delete. 
         begin
+          $LOG.info("Removing the pid file")
           File.unlink(f_pid)
         rescue
           $LOG.error( "Error deleting PID file." )

--- a/lib/winter/service/stop.rb
+++ b/lib/winter/service/stop.rb
@@ -39,9 +39,7 @@ module Winter
         end
 
         begin
-          pgid = Process.getpgid pid
-          pgid *= -1 if !config['daemonize']
-          Process.kill("TERM", pgid)
+          Process.kill("TERM", pid)
         rescue => e
           $LOG.debug( e )
           $LOG.info( "Process #{pid} does not exist. Removing pid file." )


### PR DESCRIPTION
Build will now properly end with an error code when a child mvn process fails at life.
Start will now get the pid of the java process rather than the subshell its launched from. 
Daemon mode will now fully exec the java process rather than try and propagate signals to it.
Status & Stop have a little more handling around 'failures' to parse the pid file. 
Stop will block and wait for its child to come down before exits... fewer surprises that way. 
Stop will kill by pid not process group. 
