### PR TITLE
Prefer Artifactory Rest API and File Copy over mvn invocations

### DIFF
--- a/lib/winter/dependency.rb
+++ b/lib/winter/dependency.rb
@@ -15,6 +15,7 @@
 require 'winter/logger'
 require 'fileutils'
 require 'digest/md5'
+require 'net/http'
 
 module Winter
 
@@ -41,11 +42,19 @@ module Winter
     end
     
     def get    
-      FileUtils.mkdir_p @destination unless File.directory?(@destination) 
-      #Skip the pig that is mvn if we're going to the artifactory
+      if ! File.directory?(@destination)  
+        $LOG.debug "Create the destination folder if its not already there."
+        FileUtils.mkdir_p @destination  
+      end
+      #Try and get file in a couple different ways. If we succeed then move on. 
+      #Artifacts in your local .m2 ALWAYS take precedence over a remote artifact...
+      #Unless we fail so hard we end up using mvn as a last ditched effort. 
       success = getLocalM2
       success = getRestArtifactory if ! success and ! @offline 
-      success = getMaven if ! success and system( 'which mvn > /dev/null' ) #Falback to mvn... if we can :(
+      success = getMaven if ! success and system( 'which mvn > /dev/null' ) 
+      if ! success
+        $LOG.info "[failed] #{outputFilename}"
+      end
       return success
     end
     
@@ -56,43 +65,63 @@ module Winter
     def dest_file
       File.join(@destination,outputFilename)
     end
-
+    
+    def restRequest(uri)
+      response = Net::HTTP.get_response(uri)
+      $LOG.debug "#{outputFilename}: Rest request to #{uri.inspect} #{response.inspect}"
+      return response.body if response.is_a?(Net::HTTPSuccess)
+      raise "Rest request got a bad response code back [#{response.code}]" 
+    end
+    
     def getRestArtifactory 
-      $LOG.info "Try and fetch #{dest_file}."
-      $LOG.debug "Create the destination folder if its not already there."
-      success = false
+      $LOG.debug "#{outputFilename}: Attempting to fetch via the artifactory rest api."
+      #Loop through all the repos until something works
       @repositories.each { |repo| 
-        c =  "exec wget #{repo}/#{artifactory_path}"
-        c << " -O #{dest_file} &>/dev/null"
-        $LOG.info c 
-        
-        if system( c )
-          success = true
-          m = "curl #{repo}/#{artifactory_path}.md5 2>/dev/null"
-          $LOG.debug m
-          artifactory_md5 = `#{m}`
+        begin
+          open(dest_file,"wb") { |file|
+            file.write(restRequest(URI.parse("#{repo}/#{artifactory_path}")))
+          }
+        rescue RuntimeError => e # :( Maybe do better handling later. 
+          $LOG.error "#{outputFilename}: Unable to fetch Artifact from #{repo}/#{artifactory_path}"  
+          $LOG.debug e
+          next
+        end 
+        #Check to make sure the md5sum of what we downloaded matches what's in the artifactory.
+        begin
+          artifactory_md5 = restRequest(URI.parse("#{repo}/#{artifactory_path}.md5"))
           my_md5 = Digest::MD5.file("#{dest_file}").hexdigest
-          $LOG.info "Comparing remote MD5 #{artifactory_md5} to local md5 #{my_md5} (#{dest_file})" 
-          break if artifactory_md5 == my_md5
-          $LOG.info "Comparison failed. Deleting the jar and signalling a failure" 
-          success = false
+        rescue RuntimeError => e # :( Do better handling later. 
+          $LOG.error "#{outputFilename}: Blew up while attempting to get md5s."
+        else
+          if artifactory_md5 == my_md5
+            $LOG.debug "#{outputFilename}: Successfully fetched via artifactory rest api."
+            $LOG.info "[remote] #{outputFilename}"
+            return true 
+          end
+          $LOG.error "#{outputFilename}: Comparing remote MD5 #{artifactory_md5} to local md5 #{my_md5} (#{dest_file})" 
+          $LOG.error "#{outputFilename}: Comparison failed. Deleting the 'bad' jar and moving on." 
           FileUtils.rm(dest_file)
         end
       }
-      $LOG.info "Fetch Successful." if success 
-      return success
+      return false
     end
     
     def getLocalM2 
       begin
         artifact = "#{ENV["HOME"]}/.m2/repository/#{artifactory_path}"
-        $LOG.info "Copying #{artifact} to #{dest_file}"
+        $LOG.debug "#{outputFilename}: Copying #{artifact} to #{dest_file}"
         FileUtils.cp(artifact,dest_file)
-      rescue Exception=>e
-        $LOG.error e 
-        return false
+      rescue Errno::ENOENT
+      	$LOG.debug "#{outputFilename}: #{artifact} does not exist."
+      rescue SystemCallError => e
+        $LOG.error "#{outputFilename}: Failed to copy file from local m2 repository."
+        $LOG.error e
+      else #Yay we got it
+      	$LOG.debug "#{outputFilename}: Successfully copied from local m2 repository."
+        $LOG.info "[local]  #{outputFilename}"
+        return true
       end
-      return true
+      return false
     end
 
     #Depricated because its slow and expensive to use... leaving it here for now.

--- a/lib/winter/dependency.rb
+++ b/lib/winter/dependency.rb
@@ -70,7 +70,7 @@ module Winter
     end
 
     def getMaven
-      return get #just testing
+      get unless @offline #Skip the pig that is mvn if we're going to the artifactory
       dest_file = File.join(@destination,outputFilename)
       
       c =  "exec mvn org.apache.maven.plugins:maven-dependency-plugin:2.5:get " 

--- a/lib/winter/service/build.rb
+++ b/lib/winter/service/build.rb
@@ -88,7 +88,7 @@ module Winter
             #Get the dependency and Vomit up an error code if we fail
             #If we don't do this then the main proc has no idea the build
             # was garbage 
-            exit 1 unless dep.getMaven 
+            exit 1 unless dep.get
           end
         else
           $LOG.info "Already have #{dep.outputFilename}"

--- a/lib/winter/version.rb
+++ b/lib/winter/version.rb
@@ -13,5 +13,5 @@
 # under the License.
 
 module Winter
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -34,7 +34,8 @@ describe Winter do
       begin 
         lambda {
           cli = Winter::CLI.new
-          cli.fetch 'com.liveops.sample', 'winter', '1.0.0-SNAPSHOT'
+          cli.fetch 'com.liveops.sample', 'sample', '1.0.0-SNAPSHOT'
+          #cli.fetch 'http://artifactory:8081/artifactory/libs-all/', 'sample', '1.0.0-SNAPSHOT'
         }.should_not raise_error
       end
     end
@@ -66,7 +67,7 @@ describe Winter do
     it "Build a service from a manifest" do
       begin
         lambda {
-          args = ["build", "spec/sample_data/Winterfile", "--clean", "--local"]
+          args = ["build", "spec/sample_data/Winterfile", "--clean"]
           cli = Winter::CLI.start( args )
         }.should_not raise_error
         Dir["run/default/libs"].include? "maven-dependency-plugin-2.5.jar"
@@ -79,7 +80,7 @@ describe Winter do
     context "start, status and stop " do
       before "build service to get artifacts." do
         lambda {
-          args = ["build", "spec/sample_data/Winterfile", "--clean", "--local"]
+          args = ["build", "spec/sample_data/Winterfile", "--clean"]
           cli = Winter::CLI.start( args )
         }.should_not raise_error
       end
@@ -90,12 +91,8 @@ describe Winter do
             lambda {
               Winter::CLI.start ["start"]
               Winter::CLI.start ["status"]
-              #Winter::CLI.start ["stop"]
+              Winter::CLI.start ["stop"]
             }.should_not raise_error
-            #lambda {
-            #  puts "TRYING STOP"
-            #  Winter::CLI.start ["stop"]
-            #}.should_not raise_error
           end
         end
       end
@@ -113,7 +110,7 @@ describe Winter do
 
     after do
       Dir.chdir(File.split("spec/sample_data/Winterfile")[0]) do
-        #Winter::CLI.start ["stop"]
+        Winter::CLI.start ["stop"]
       end
 
       FileUtils.rm_r( "spec/sample_data/run" )


### PR DESCRIPTION
Prefer Artifactory Rest API and FileUtils.cp from a local .m2 repo to get artifacts into place mvn is left as a final fallback.  Local artifacts of the correct version/tag are guaranteed to always be favored over remote artifacts unless we fall back to mvn.

Spec also received some minor changes; Namely it will now:
Invoke some functionality that was not being really tested before. 
Build tests will not force local resolution. 
Fetch will look for an artifact named 'sample' rather than winter.

Spec tests still need a lot more love. 
