### PR TITLE
0.1.1 RC Parse metadata.xml files so that we can get Snapshot Artifacts reliably. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gemspec
 
 gem 'thor'
 gem 'bundler'
-
 gem 'multi_json'
+gem 'nori'
 
 group :test do
   gem 'json', '~> 1.7.7'

--- a/lib/winter/dependency.rb
+++ b/lib/winter/dependency.rb
@@ -59,12 +59,13 @@ module Winter
       return success
     end
    
-    def resolve_snapshot_name(maven_metadata)
+    def determine_repo_artifact_name(maven_metadata)
+      return @version if maven_metadata == nil
       parser = Nori.new
       meta = parser.parse(maven_metadata)
       ts = meta['metadata']['versioning']['snapshot']['timestamp']
       bn = meta['metadata']['versioning']['snapshot']['buildNumber']
-      "#{ts}-#{bn}"
+      @version.gsub(/SNAPSHOT/){ |s| "#{ts}-#{bn}" } 
     end
 
     def metadata_path
@@ -72,9 +73,7 @@ module Winter
     end
 
     def generate_artifactory_path(meta = nil)
-      real_version = @version
-      real_version = @version.gsub(/SNAPSHOT/){ |s| resolve_snapshot_name(meta) } if meta != nil #MVN 3 uses unique names
-      "#{@group.gsub(/\./,'/')}/#{@artifact}/#{@version}/#{@artifact}-#{real_version}.#{@package}"
+      "#{@group.gsub(/\./,'/')}/#{@artifact}/#{@version}/#{@artifact}-#{determine_repo_artifact_name(meta)}.#{@package}"
     end
 
     def dest_file

--- a/lib/winter/dependency.rb
+++ b/lib/winter/dependency.rb
@@ -50,6 +50,8 @@ module Winter
       #Try and get file in a couple different ways. If we succeed then move on. 
       #Artifacts in your local .m2 ALWAYS take precedence over a remote artifact...
       #Unless we fail so hard we end up using mvn as a last ditched effort. 
+      return getMaven
+      
       success = getLocalM2
       success = getRestArtifactory if ! success and ! @offline 
       success = getMaven if ! success and system( 'which mvn > /dev/null' ) 
@@ -57,6 +59,106 @@ module Winter
         $LOG.info "[failed] #{outputFilename}"
       end
       return success
+    end
+
+    def getLocalM2 
+      log_prefix = "[local]  #{outputFilename}"
+      local_repo = "#{ENV["HOME"]}/.m2/repository"
+      begin
+        artifactory_path = get_repo_path 
+        artifactory_path = get_repo_path(File.read("#{local_repo}/#{metadata_path}")) if @version.include?("SNAPSHOT")
+        artifact = "#{local_repo}/#{artifactory_path}"
+        $LOG.debug "#{log_prefix}: Copying #{artifact} to #{dest_file}"
+        FileUtils.cp(artifact,dest_file)
+      rescue Errno::ENOENT
+      	$LOG.debug "#{log_prefix}: #{artifact} does not exist."
+      rescue SystemCallError => e
+        $LOG.error "#{log_prefix}: Failed to copy file from local m2 repository."
+        $LOG.error e
+      else #Yay we got it
+        $LOG.debug "#{log_prefix}: Successfully copied from local m2 repository."
+        $LOG.info "#{log_prefix}"
+        return true
+      end
+      return false
+    end
+
+    def getRestArtifactory 
+      log_prefix = "[remote] #{outputFilename}"
+      artifactory_path = get_repo_path
+      $LOG.debug "#{log_prefix}: Attempting to fetch via the artifactory rest api."
+      #Loop through all the repos until something works
+      @repositories.each { |repo| 
+        begin
+          artifactory_path = get_repo_path(restRequest(URI.parse("#{repo}/#{metadata_path}"))) if @version.include?("SNAPSHOT")
+          open(dest_file,"wb") { |file|
+            file.write(restRequest(URI.parse("#{repo}/#{artifactory_path}")))
+          }
+        rescue SocketError,RuntimeError => e # :( Maybe do better handling later. 
+          $LOG.error "#{log_prefix}: Failed to fetch Artifact #{repo}/#{artifactory_path}"  
+          $LOG.debug e
+          next
+        end 
+
+        #Check to make sure the md5sum of what we downloaded matches what's in the artifactory.
+        begin
+          artifactory_md5 = restRequest(URI.parse("#{repo}/#{artifactory_path}.md5"))
+          my_md5 = Digest::MD5.file("#{dest_file}").hexdigest
+        rescue SocketError, RuntimeError => e # :( Do better handling later. 
+          $LOG.error "#{log_prefix}: Blew up while attempting to get md5s."
+        else
+          if artifactory_md5 == my_md5
+            $LOG.debug "#{log_prefix}: Successfully fetched via artifactory rest api."
+            $LOG.info "#{log_prefix}"
+            return true 
+          end
+          $LOG.error "#{log_prefix}: Remote md5 #{artifactory_md5} didn't match #{my_md5}" 
+          $LOG.error "#{log_prefix}: Deleting the 'bad' jar and moving on." 
+          FileUtils.rm(dest_file)
+        end
+      }
+      return false
+    end
+
+    #Depricated because its slow and expensive to use... leaving it here for now.
+    def getMaven
+      log_prefix = "[maven]  #{outputFilename}"
+      
+      c =  "mvn org.apache.maven.plugins:maven-dependency-plugin:2.5:get" 
+      c << " -DremoteRepositories=#{@repositories.join(',').shellescape}" 
+      c << " -Dtransitive=#{@transative}"
+      c << " -Dartifact=" + "#{@group}:#{@artifact}:#{@version}:#{@package}".shellescape
+      c << " -Ddest=#{dest_file.shellescape}"
+      c << " &>/dev/null"
+
+      if @offline
+        c << " --offline"
+      end
+
+      if !@verbose
+        #quiet mode is default
+        c << " -q"
+      end
+      
+      result = system( c )
+      if result == false
+        $LOG.error("#{log_prefix}: Failed to retrieve artifact. -- #{c}")
+      else
+        $LOG.info "#{log_prefix}"
+      end
+      return result
+    end
+    
+    def metadata_path
+      "#{@group.gsub(/\./,'/')}/#{@artifact}/#{@version}/maven-metadata.xml"
+    end
+    
+    def outputFilename
+      "#{@artifact}-#{@version}.#{@package}"
+    end
+    
+    def dest_file
+      File.join(@destination,outputFilename)
     end
    
     def determine_repo_artifact_name(maven_metadata)
@@ -68,16 +170,10 @@ module Winter
       @version.gsub(/SNAPSHOT/){ |s| "#{ts}-#{bn}" } 
     end
 
-    def metadata_path
-      "#{@group.gsub(/\./,'/')}/#{@artifact}/#{@version}/maven-metadata.xml"
-    end
-
-    def generate_artifactory_path(meta = nil)
-      "#{@group.gsub(/\./,'/')}/#{@artifact}/#{@version}/#{@artifact}-#{determine_repo_artifact_name(meta)}.#{@package}"
-    end
-
-    def dest_file
-      File.join(@destination,outputFilename)
+    def get_repo_path(meta = nil)
+      path = "#{@group.gsub(/\./,'/')}/#{@artifact}/#{@version}/"
+      path << "#{@artifact}-#{determine_repo_artifact_name(meta)}.#{@package}"
+      path
     end
     
     def restRequest(uri)
@@ -85,98 +181,6 @@ module Winter
       return response.body if response.is_a?(Net::HTTPSuccess)
       $LOG.debug "#{outputFilename}: Rest request to #{uri.inspect} #{response.inspect}"
       raise "Rest request got a bad response code back [#{response.code}]" 
-    end
-    
-    def getRestArtifactory 
-      log_prefix = '[remote] '
-      artifactory_path = generate_artifactory_path
-
-      $LOG.debug "#{log_prefix}#{outputFilename}: Attempting to fetch via the artifactory rest api."
-      #Loop through all the repos until something works
-      @repositories.each { |repo| 
-        begin
-          artifactory_path = generate_artifactory_path(restRequest(URI.parse("#{repo}/#{metadata_path}"))) if @version.include?("SNAPSHOT")
-          open(dest_file,"wb") { |file|
-            file.write(restRequest(URI.parse("#{repo}/#{artifactory_path}")))
-          }
-        rescue SocketError,RuntimeError => e # :( Maybe do better handling later. 
-          $LOG.error "#{log_prefix}#{outputFilename}: Unable to fetch Artifact from #{repo}/#{artifactory_path}"  
-          $LOG.debug e
-          next
-        end 
-
-        #Check to make sure the md5sum of what we downloaded matches what's in the artifactory.
-        begin
-          artifactory_md5 = restRequest(URI.parse("#{repo}/#{artifactory_path}.md5"))
-          my_md5 = Digest::MD5.file("#{dest_file}").hexdigest
-        rescue SocketError, RuntimeError => e # :( Do better handling later. 
-          $LOG.error "#{log_prefix}#{outputFilename}: Blew up while attempting to get md5s."
-        else
-          if artifactory_md5 == my_md5
-            $LOG.debug "#{log_prefix}#{outputFilename}: Successfully fetched via artifactory rest api."
-            $LOG.info "#{log_prefix}#{outputFilename}"
-            return true 
-          end
-          $LOG.error "#{log_prefix}#{outputFilename}: Comparing remote MD5 #{artifactory_md5} to local md5 #{my_md5} (#{dest_file})" 
-          $LOG.error "#{log_prefix}#{outputFilename}: Comparison failed. Deleting the 'bad' jar and moving on." 
-          FileUtils.rm(dest_file)
-        end
-      }
-      return false
-    end
-    
-    def getLocalM2 
-      log_prefix = "[local]  "
-      local_repo = "#{ENV["HOME"]}/.m2/repository"
-      begin
-        artifactory_path = generate_artifactory_path 
-        artifactory_path = generate_artifactory_path(File.read("#{local_repo}/#{metadata_path}")) if @version.include?("SNAPSHOT")
-        artifact = "#{local_repo}/#{artifactory_path}"
-        $LOG.debug "#{log_prefix}#{outputFilename}: Copying #{artifact} to #{dest_file}"
-        FileUtils.cp(artifact,dest_file)
-      rescue Errno::ENOENT
-      	$LOG.debug "#{log_prefix}#{outputFilename}: #{artifact} does not exist."
-      rescue SystemCallError => e
-        $LOG.error "#{log_prefix}#{outputFilename}: Failed to copy file from local m2 repository."
-        $LOG.error e
-      else #Yay we got it
-        $LOG.debug "#{log_prefix}#{outputFilename}: Successfully copied from local m2 repository."
-        $LOG.info "#{log_prefix}#{outputFilename}"
-        return true
-      end
-      return false
-    end
-
-    #Depricated because its slow and expensive to use... leaving it here for now.
-    def getMaven
-      log_prefix = "[maven]  "
-      c =  "mvn org.apache.maven.plugins:maven-dependency-plugin:2.5:get " 
-      c << " -DremoteRepositories=#{@repositories.join(',').shellescape}" 
-      c << " -Dtransitive=#{@transative}" 
-      c << " -Dartifact=#{@group.shellescape}:#{@artifact.shellescape}:#{@version.shellescape}:#{@package.shellescape}" 
-      c << " -Ddest=#{dest_file.shellescape} &>/dev/null"
-
-      if @offline
-        c << " --offline"
-      end
-
-      if !@verbose
-        #quiet mode is default
-        c << " -q"
-      end
-
-      result = system( c )
-      if result == false
-        $LOG.error("#{log_prefix}#{outputFilename}: Failed to retrieve artifact. -- #{c}")
-      else
-        $LOG.info "#{log_prefix}#{@group}:#{@artifact}:#{@version}:#{@package}"
-        $LOG.debug "#{log_prefix}#{dest_file}"
-      end
-      return result
-    end
-
-    def outputFilename
-      "#{@artifact}-#{@version}.#{@package}"
     end
   end
 

--- a/lib/winter/dependency.rb
+++ b/lib/winter/dependency.rb
@@ -50,8 +50,6 @@ module Winter
       #Try and get file in a couple different ways. If we succeed then move on. 
       #Artifacts in your local .m2 ALWAYS take precedence over a remote artifact...
       #Unless we fail so hard we end up using mvn as a last ditched effort. 
-      return getMaven
-      
       success = getLocalM2
       success = getRestArtifactory if ! success and ! @offline 
       success = getMaven if ! success and system( 'which mvn > /dev/null' ) 

--- a/lib/winter/service/fetch.rb
+++ b/lib/winter/service/fetch.rb
@@ -51,7 +51,7 @@ module Winter
       dep.transative    = true
       dep.destination   = File.join('.')
 
-      dep.getMaven
+      dep.get
 
       extract_jar "#{artifact}-#{version}.jar"
     end

--- a/lib/winter/service/fetch.rb
+++ b/lib/winter/service/fetch.rb
@@ -51,7 +51,7 @@ module Winter
       dep.transative    = true
       dep.destination   = File.join('.')
 
-      dep.get
+      dep.get or raise "Failed to fetch jar."
 
       extract_jar "#{artifact}-#{version}.jar"
     end

--- a/lib/winter/version.rb
+++ b/lib/winter/version.rb
@@ -13,5 +13,5 @@
 # under the License.
 
 module Winter
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/winter.gemspec
+++ b/winter.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.1'
 
-  spec.add_runtime_dependency "thor", "~> 0.14.0"
+  spec.add_runtime_dependency "thor", "~> 0.14"
+  spec.add_runtime_dependency "nori", "~> 2.4"
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 10"
 end


### PR DESCRIPTION
Introduced a dependency on nori (for xml parsing). 
Cleaned up the logging. 
Parse the metadata to determine the name of the snapshot artifact we want to snag for local and remote repos. 
Don't explicitly use mvn if we're doing a fetch (Just call dependency.get like we do for every other jar) and bomb out hard if we fail. 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/liveops/winter/18)

<!-- Reviewable:end -->
